### PR TITLE
Add Xfce to Owens

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/owens.yml
+++ b/apps.awesim.org/apps/bc_desktop/owens.yml
@@ -2,7 +2,19 @@
 title: "Owens Desktop"
 cluster: "owens"
 attributes:
-  desktop: "xfce"
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Owens cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Owens cluster]: https://www.osc.edu/resources/technical_support/supercomputers/owens
   bc_queue: null
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."

--- a/apps.awesim.org/apps/bc_desktop/owens.yml
+++ b/apps.awesim.org/apps/bc_desktop/owens.yml
@@ -2,7 +2,7 @@
 title: "Owens Desktop"
 cluster: "owens"
 attributes:
-  desktop: "mate"
+  desktop: "xfce"
   bc_queue: null
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."

--- a/apps.awesim.org/apps/bc_desktop/vdi-owens.yml
+++ b/apps.awesim.org/apps/bc_desktop/vdi-owens.yml
@@ -14,7 +14,19 @@ description: |
   - running visualization software
 cluster: "quick"
 attributes:
-  desktop: "xfce"
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Owens cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Owens cluster]: https://www.osc.edu/resources/technical_support/supercomputers/owens
   bc_num_slots: 1
   bc_num_hours:
     value: 8

--- a/apps.awesim.org/apps/bc_desktop/vdi-owens.yml
+++ b/apps.awesim.org/apps/bc_desktop/vdi-owens.yml
@@ -14,7 +14,7 @@ description: |
   - running visualization software
 cluster: "quick"
 attributes:
-  desktop: "mate"
+  desktop: "xfce"
   bc_num_slots: 1
   bc_num_hours:
     value: 8

--- a/ondemand.osc.edu/apps/bc_desktop/owens.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/owens.yml
@@ -2,7 +2,19 @@
 title: "Owens Desktop"
 cluster: "owens"
 attributes:
-  desktop: "xfce"
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Owens cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Owens cluster]: https://www.osc.edu/resources/technical_support/supercomputers/owens
   bc_queue: null
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."

--- a/ondemand.osc.edu/apps/bc_desktop/owens.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/owens.yml
@@ -2,7 +2,7 @@
 title: "Owens Desktop"
 cluster: "owens"
 attributes:
-  desktop: "mate"
+  desktop: "xfce"
   bc_queue: null
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."

--- a/ondemand.osc.edu/apps/bc_desktop/vdi-owens.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/vdi-owens.yml
@@ -14,7 +14,19 @@ description: |
   - running visualization software
 cluster: "quick"
 attributes:
-  desktop: "xfce"
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Owens cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Owens cluster]: https://www.osc.edu/resources/technical_support/supercomputers/owens
   bc_num_slots: 1
   bc_num_hours:
     value: 8

--- a/ondemand.osc.edu/apps/bc_desktop/vdi-owens.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/vdi-owens.yml
@@ -14,7 +14,7 @@ description: |
   - running visualization software
 cluster: "quick"
 attributes:
-  desktop: "mate"
+  desktop: "xfce"
   bc_num_slots: 1
   bc_num_hours:
     value: 8

--- a/ood.osc.edu/apps/bc_desktop/owens.yml
+++ b/ood.osc.edu/apps/bc_desktop/owens.yml
@@ -2,7 +2,19 @@
 title: "Owens Desktop"
 cluster: "owens"
 attributes:
-  desktop: "xfce"
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Owens cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Owens cluster]: https://www.osc.edu/resources/technical_support/supercomputers/owens
   bc_queue: null
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."

--- a/ood.osc.edu/apps/bc_desktop/owens.yml
+++ b/ood.osc.edu/apps/bc_desktop/owens.yml
@@ -2,7 +2,7 @@
 title: "Owens Desktop"
 cluster: "owens"
 attributes:
-  desktop: "mate"
+  desktop: "xfce"
   bc_queue: null
   bc_account:
     help: "You can leave this blank if **not** in multiple projects."

--- a/ood.osc.edu/apps/bc_desktop/vdi-owens.yml
+++ b/ood.osc.edu/apps/bc_desktop/vdi-owens.yml
@@ -14,7 +14,19 @@ description: |
   - running visualization software
 cluster: "quick"
 attributes:
-  desktop: "xfce"
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Owens cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Owens cluster]: https://www.osc.edu/resources/technical_support/supercomputers/owens
   bc_num_slots: 1
   bc_num_hours:
     value: 8

--- a/ood.osc.edu/apps/bc_desktop/vdi-owens.yml
+++ b/ood.osc.edu/apps/bc_desktop/vdi-owens.yml
@@ -14,7 +14,7 @@ description: |
   - running visualization software
 cluster: "quick"
 attributes:
-  desktop: "mate"
+  desktop: "xfce"
   bc_num_slots: 1
   bc_num_hours:
     value: 8


### PR DESCRIPTION
Requires `bc_desktop` >0.1.2. Allows user to choose between Mate or Xfce desktop for Owens, with Xfce being default.