### PR TITLE
add Pitzer desktop config

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/pitzer.yml
+++ b/apps.awesim.org/apps/bc_desktop/pitzer.yml
@@ -22,25 +22,22 @@ attributes:
     widget: select
     label: "Node type"
     help: |
-      - **any** - (*12 cores*) Chooses anyone of the available Pitzer nodes.
+      - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
-        VirtualGL. There are currently only 128 of these nodes on Pitzer.
-      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
-        allowing for CUDA computations. There are currently only 128 of these
+        VirtualGL. There are currently only 32 of these nodes on Pitzer.
+      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+        allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.
-      - **bigmem** - (*12 cores*) This Pitzer node comes with 192GB of
-        available RAM. There are only 8 of these nodes on Pitzer.
-      - **hugemem** - (*32 cores*) This Pitzer node has 1TB of available RAM as
-        well as 32 cores. There is only 1 of these nodes on Pitzer. A
+      - **hugemem** - (*80 cores*) This Pitzer node has 3TB of available RAM as
+        well as 80 cores. There are only 4 of these nodes on Pitzer. A
         reservation may be required to use this node.
     options:
-      - ["any", ":ppn=12"]
-      - ["vis", ":ppn=12:vis:gpus=1"]
-      - ["gpu", ":ppn=12:gpus=1"]
-      - ["bigmem", ":ppn=12:bigmem"]
-      - ["hugemem", ":ppn=32:hugemem"]
+      - ["any", ":ppn=40"]
+      - ["vis", ":ppn=40:vis:gpus=1"]
+      - ["gpu", ":ppn=40:gpus=1"]
+      - ["hugemem", ":ppn=80:hugemem"]
 submit: submit/pbs.yml.erb

--- a/apps.awesim.org/apps/bc_desktop/pitzer.yml
+++ b/apps.awesim.org/apps/bc_desktop/pitzer.yml
@@ -36,8 +36,8 @@ attributes:
         well as 80 cores. There are only 4 of these nodes on Pitzer. A
         reservation may be required to use this node.
     options:
-      - ["any", ":ppn=40"]
-      - ["vis", ":ppn=40:vis:gpus=1"]
-      - ["gpu", ":ppn=40:gpus=1"]
-      - ["hugemem", ":ppn=80:hugemem"]
+      - ["any (ppn=40)", ":ppn=40"]
+      - ["vis (ppn=40:vis:gpus=1)", ":ppn=40:vis:gpus=1"]
+      - ["gpu (ppn=40:gpus=1)", ":ppn=40:gpus=1"]
+      - ["hugemem (ppn=80:hugemem)", ":ppn=80:hugemem"]
 submit: submit/pbs.yml.erb

--- a/apps.awesim.org/apps/bc_desktop/pitzer.yml
+++ b/apps.awesim.org/apps/bc_desktop/pitzer.yml
@@ -24,11 +24,11 @@ attributes:
     help: |
       - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
         VirtualGL. There are currently only 32 of these nodes on Pitzer.
-      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+      - **gpu** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
         allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.

--- a/apps.awesim.org/apps/bc_desktop/pitzer.yml
+++ b/apps.awesim.org/apps/bc_desktop/pitzer.yml
@@ -1,0 +1,46 @@
+---
+title: "Pitzer Desktop"
+cluster: "pitzer"
+attributes:
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Pitzer cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Pitzer cluster]: https://www.osc.edu/supercomputing/computing/pitzer
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Pitzer nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Pitzer.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Pitzer. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Pitzer node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Pitzer.
+      - **hugemem** - (*32 cores*) This Pitzer node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Pitzer. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/apps.awesim.org/apps/bc_desktop/pitzer.yml
+++ b/apps.awesim.org/apps/bc_desktop/pitzer.yml
@@ -24,11 +24,11 @@ attributes:
     help: |
       - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
         VirtualGL. There are currently only 32 of these nodes on Pitzer.
-      - **gpu** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
+      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.

--- a/apps.awesim.org/apps/bc_desktop/vdi-pitzer.yml
+++ b/apps.awesim.org/apps/bc_desktop/vdi-pitzer.yml
@@ -1,0 +1,38 @@
+---
+title: "Pitzer VDI"
+description: |
+  This app will launch an interactive desktop on a **shared node** that we have
+  termed a Virtual Desktop Interface (VDI). This is analogous to an interactive
+  login node as you will be sharing it with multiple users and you *should* be
+  provisioned a desktop nearly immediately.
+
+  This is meant for lightweight tasks (similar to a login node) such as:
+
+  - accessing & viewing files
+  - submitting jobs
+  - compiling code
+  - running visualization software
+cluster: "quick"
+attributes:
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Pitzer cluster].
+    
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Pitzer cluster]: https://www.osc.edu/supercomputing/computing/pitzer
+  bc_num_slots: 1
+  bc_num_hours:
+    value: 8
+  bc_queue: null
+  node_type: ":ppn=1:pitzer"
+  bc_email_on_started: 0
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+submit: submit/pbs.yml.erb

--- a/apps.awesim.org/apps/bc_desktop/vdi-pitzer.yml
+++ b/apps.awesim.org/apps/bc_desktop/vdi-pitzer.yml
@@ -12,7 +12,7 @@ description: |
   - submitting jobs
   - compiling code
   - running visualization software
-cluster: "quick"
+cluster: "quick_pitzer"
 attributes:
   desktop:
     widget: select

--- a/apps.awesim.org/apps/bc_desktop/vdi-ruby.yml
+++ b/apps.awesim.org/apps/bc_desktop/vdi-ruby.yml
@@ -12,7 +12,7 @@ description: |
   - submitting jobs
   - compiling code
   - running visualization software
-cluster: "quick"
+cluster: "quick_ruby"
 attributes:
   desktop: "gnome"
   bc_num_slots: 1

--- a/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
@@ -22,25 +22,22 @@ attributes:
     widget: select
     label: "Node type"
     help: |
-      - **any** - (*12 cores*) Chooses anyone of the available Pitzer nodes.
+      - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
-        VirtualGL. There are currently only 128 of these nodes on Pitzer.
-      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
-        allowing for CUDA computations. There are currently only 128 of these
+        VirtualGL. There are currently only 32 of these nodes on Pitzer.
+      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+        allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.
-      - **bigmem** - (*12 cores*) This Pitzer node comes with 192GB of
-        available RAM. There are only 8 of these nodes on Pitzer.
-      - **hugemem** - (*32 cores*) This Pitzer node has 1TB of available RAM as
-        well as 32 cores. There is only 1 of these nodes on Pitzer. A
+      - **hugemem** - (*80 cores*) This Pitzer node has 3TB of available RAM as
+        well as 80 cores. There are only 4 of these nodes on Pitzer. A
         reservation may be required to use this node.
     options:
-      - ["any", ":ppn=12"]
-      - ["vis", ":ppn=12:vis:gpus=1"]
-      - ["gpu", ":ppn=12:gpus=1"]
-      - ["bigmem", ":ppn=12:bigmem"]
-      - ["hugemem", ":ppn=32:hugemem"]
+      - ["any", ":ppn=40"]
+      - ["vis", ":ppn=40:vis:gpus=1"]
+      - ["gpu", ":ppn=40:gpus=1"]
+      - ["hugemem", ":ppn=80:hugemem"]
 submit: submit/pbs.yml.erb

--- a/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
@@ -36,8 +36,8 @@ attributes:
         well as 80 cores. There are only 4 of these nodes on Pitzer. A
         reservation may be required to use this node.
     options:
-      - ["any", ":ppn=40"]
-      - ["vis", ":ppn=40:vis:gpus=1"]
-      - ["gpu", ":ppn=40:gpus=1"]
-      - ["hugemem", ":ppn=80:hugemem"]
+      - ["any (ppn=40)", ":ppn=40"]
+      - ["vis (ppn=40:vis:gpus=1)", ":ppn=40:vis:gpus=1"]
+      - ["gpu (ppn=40:gpus=1)", ":ppn=40:gpus=1"]
+      - ["hugemem (ppn=80:hugemem)", ":ppn=80:hugemem"]
 submit: submit/pbs.yml.erb

--- a/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
@@ -24,11 +24,11 @@ attributes:
     help: |
       - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
         VirtualGL. There are currently only 32 of these nodes on Pitzer.
-      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+      - **gpu** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
         allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.

--- a/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
@@ -1,0 +1,46 @@
+---
+title: "Pitzer Desktop"
+cluster: "pitzer"
+attributes:
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Pitzer cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Pitzer cluster]: https://www.osc.edu/supercomputing/computing/pitzer
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Pitzer nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Pitzer.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Pitzer. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Pitzer node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Pitzer.
+      - **hugemem** - (*32 cores*) This Pitzer node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Pitzer. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/pitzer.yml
@@ -24,11 +24,11 @@ attributes:
     help: |
       - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
         VirtualGL. There are currently only 32 of these nodes on Pitzer.
-      - **gpu** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
+      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.

--- a/ondemand.osc.edu/apps/bc_desktop/vdi-pitzer.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/vdi-pitzer.yml
@@ -1,0 +1,38 @@
+---
+title: "Pitzer VDI"
+description: |
+  This app will launch an interactive desktop on a **shared node** that we have
+  termed a Virtual Desktop Interface (VDI). This is analogous to an interactive
+  login node as you will be sharing it with multiple users and you *should* be
+  provisioned a desktop nearly immediately.
+
+  This is meant for lightweight tasks (similar to a login node) such as:
+
+  - accessing & viewing files
+  - submitting jobs
+  - compiling code
+  - running visualization software
+cluster: "quick"
+attributes:
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Pitzer cluster].
+    
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Pitzer cluster]: https://www.osc.edu/supercomputing/computing/pitzer
+  bc_num_slots: 1
+  bc_num_hours:
+    value: 8
+  bc_queue: null
+  node_type: ":ppn=1:pitzer"
+  bc_email_on_started: 0
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+submit: submit/pbs.yml.erb

--- a/ondemand.osc.edu/apps/bc_desktop/vdi-pitzer.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/vdi-pitzer.yml
@@ -12,7 +12,7 @@ description: |
   - submitting jobs
   - compiling code
   - running visualization software
-cluster: "quick"
+cluster: "quick_pitzer"
 attributes:
   desktop:
     widget: select

--- a/ondemand.osc.edu/apps/bc_desktop/vdi-ruby.yml
+++ b/ondemand.osc.edu/apps/bc_desktop/vdi-ruby.yml
@@ -12,7 +12,7 @@ description: |
   - submitting jobs
   - compiling code
   - running visualization software
-cluster: "quick"
+cluster: "quick_ruby"
 attributes:
   desktop: "gnome"
   bc_num_slots: 1

--- a/ood.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ood.osc.edu/apps/bc_desktop/pitzer.yml
@@ -22,25 +22,22 @@ attributes:
     widget: select
     label: "Node type"
     help: |
-      - **any** - (*12 cores*) Chooses anyone of the available Pitzer nodes.
+      - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
-        VirtualGL. There are currently only 128 of these nodes on Pitzer.
-      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
-        allowing for CUDA computations. There are currently only 128 of these
+        VirtualGL. There are currently only 32 of these nodes on Pitzer.
+      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+        allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.
-      - **bigmem** - (*12 cores*) This Pitzer node comes with 192GB of
-        available RAM. There are only 8 of these nodes on Pitzer.
-      - **hugemem** - (*32 cores*) This Pitzer node has 1TB of available RAM as
-        well as 32 cores. There is only 1 of these nodes on Pitzer. A
+      - **hugemem** - (*80 cores*) This Pitzer node has 3TB of available RAM as
+        well as 80 cores. There are only 4 of these nodes on Pitzer. A
         reservation may be required to use this node.
     options:
-      - ["any", ":ppn=12"]
-      - ["vis", ":ppn=12:vis:gpus=1"]
-      - ["gpu", ":ppn=12:gpus=1"]
-      - ["bigmem", ":ppn=12:bigmem"]
-      - ["hugemem", ":ppn=32:hugemem"]
+      - ["any", ":ppn=40"]
+      - ["vis", ":ppn=40:vis:gpus=1"]
+      - ["gpu", ":ppn=40:gpus=1"]
+      - ["hugemem", ":ppn=80:hugemem"]
 submit: submit/pbs.yml.erb

--- a/ood.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ood.osc.edu/apps/bc_desktop/pitzer.yml
@@ -36,8 +36,8 @@ attributes:
         well as 80 cores. There are only 4 of these nodes on Pitzer. A
         reservation may be required to use this node.
     options:
-      - ["any", ":ppn=40"]
-      - ["vis", ":ppn=40:vis:gpus=1"]
-      - ["gpu", ":ppn=40:gpus=1"]
-      - ["hugemem", ":ppn=80:hugemem"]
+      - ["any (ppn=40)", ":ppn=40"]
+      - ["vis (ppn=40:vis:gpus=1)", ":ppn=40:vis:gpus=1"]
+      - ["gpu (ppn=40:gpus=1)", ":ppn=40:gpus=1"]
+      - ["hugemem (ppn=80:hugemem)", ":ppn=80:hugemem"]
 submit: submit/pbs.yml.erb

--- a/ood.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ood.osc.edu/apps/bc_desktop/pitzer.yml
@@ -24,11 +24,11 @@ attributes:
     help: |
       - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
         VirtualGL. There are currently only 32 of these nodes on Pitzer.
-      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
+      - **gpu** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
         allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.

--- a/ood.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ood.osc.edu/apps/bc_desktop/pitzer.yml
@@ -1,0 +1,46 @@
+---
+title: "Pitzer Desktop"
+cluster: "pitzer"
+attributes:
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Pitzer cluster].
+
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Pitzer cluster]: https://www.osc.edu/supercomputing/computing/pitzer
+  bc_queue: null
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+  node_type:
+    widget: select
+    label: "Node type"
+    help: |
+      - **any** - (*12 cores*) Chooses anyone of the available Pitzer nodes.
+        This reduces the wait time as you have no requirements.
+      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        with an X server running in the background. This allows for Hardware
+        Rendering with the GPU typically needed for 3D visualization using
+        VirtualGL. There are currently only 128 of these nodes on Pitzer.
+      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+        allowing for CUDA computations. There are currently only 128 of these
+        nodes on Pitzer. These nodes don't start an X server, so visualization
+        with hardware rendering is not possible.
+      - **bigmem** - (*12 cores*) This Pitzer node comes with 192GB of
+        available RAM. There are only 8 of these nodes on Pitzer.
+      - **hugemem** - (*32 cores*) This Pitzer node has 1TB of available RAM as
+        well as 32 cores. There is only 1 of these nodes on Pitzer. A
+        reservation may be required to use this node.
+    options:
+      - ["any", ":ppn=12"]
+      - ["vis", ":ppn=12:vis:gpus=1"]
+      - ["gpu", ":ppn=12:gpus=1"]
+      - ["bigmem", ":ppn=12:bigmem"]
+      - ["hugemem", ":ppn=32:hugemem"]
+submit: submit/pbs.yml.erb

--- a/ood.osc.edu/apps/bc_desktop/pitzer.yml
+++ b/ood.osc.edu/apps/bc_desktop/pitzer.yml
@@ -24,11 +24,11 @@ attributes:
     help: |
       - **any** - (*40 cores*) Chooses anyone of the available Pitzer nodes.
         This reduces the wait time as you have no requirements.
-      - **vis** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
+      - **vis** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
         VirtualGL. There are currently only 32 of these nodes on Pitzer.
-      - **gpu** - (*40 cores*) This node includes an NVIDIA V100 "Volta" GPU
+      - **gpu** - (*40 cores*) This node includes an NVIDIA Tesla V100 GPU
         allowing for CUDA computations. There are currently only 32 of these
         nodes on Pitzer. These nodes don't start an X server, so visualization
         with hardware rendering is not possible.

--- a/ood.osc.edu/apps/bc_desktop/vdi-pitzer.yml
+++ b/ood.osc.edu/apps/bc_desktop/vdi-pitzer.yml
@@ -1,0 +1,38 @@
+---
+title: "Pitzer VDI"
+description: |
+  This app will launch an interactive desktop on a **shared node** that we have
+  termed a Virtual Desktop Interface (VDI). This is analogous to an interactive
+  login node as you will be sharing it with multiple users and you *should* be
+  provisioned a desktop nearly immediately.
+
+  This is meant for lightweight tasks (similar to a login node) such as:
+
+  - accessing & viewing files
+  - submitting jobs
+  - compiling code
+  - running visualization software
+cluster: "quick"
+attributes:
+  desktop:
+    widget: select
+    label: "Desktop environment"
+    options:
+      - ["Xfce", "xfce"]
+      - ["Mate", "mate"]
+    help: |
+      This will launch either the [Xfce] or [Mate] desktop environment on the
+      [Pitzer cluster].
+    
+      [Xfce]: https://xfce.org/
+      [Mate]: https://mate-desktop.org/
+      [Pitzer cluster]: https://www.osc.edu/supercomputing/computing/pitzer
+  bc_num_slots: 1
+  bc_num_hours:
+    value: 8
+  bc_queue: null
+  node_type: ":ppn=1:pitzer"
+  bc_email_on_started: 0
+  bc_account:
+    help: "You can leave this blank if **not** in multiple projects."
+submit: submit/pbs.yml.erb

--- a/ood.osc.edu/apps/bc_desktop/vdi-pitzer.yml
+++ b/ood.osc.edu/apps/bc_desktop/vdi-pitzer.yml
@@ -12,7 +12,7 @@ description: |
   - submitting jobs
   - compiling code
   - running visualization software
-cluster: "quick"
+cluster: "quick_pitzer"
 attributes:
   desktop:
     widget: select

--- a/ood.osc.edu/apps/bc_desktop/vdi-ruby.yml
+++ b/ood.osc.edu/apps/bc_desktop/vdi-ruby.yml
@@ -12,7 +12,7 @@ description: |
   - submitting jobs
   - compiling code
   - running visualization software
-cluster: "quick"
+cluster: "quick_ruby"
 attributes:
   desktop: "gnome"
   bc_num_slots: 1


### PR DESCRIPTION
This pull request adds pitzer.yml and vdi-pitzer.yml. 

It works fine but still needs more information about Pitzer node type. The current node_type information is from Ruby cluster. 
```
  node_type:
    widget: select
    label: "Node type"
    help: |
      - **any** - (*12 cores*) Chooses anyone of the available Pitzer nodes.
        This reduces the wait time as you have no requirements.
      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
        with an X server running in the background. This allows for Hardware
        Rendering with the GPU typically needed for 3D visualization using
        VirtualGL. There are currently only 128 of these nodes on Pitzer.
      - **gpu** -  (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
        allowing for CUDA computations. There are currently only 128 of these
        nodes on Pitzer. These nodes don't start an X server, so visualization
        with hardware rendering is not possible.
      - **bigmem** - (*12 cores*) This Pitzer node comes with 192GB of
        available RAM. There are only 8 of these nodes on Pitzer.
      - **hugemem** - (*32 cores*) This Pitzer node has 1TB of available RAM as
        well as 32 cores. There is only 1 of these nodes on Pitzer. A
        reservation may be required to use this node.
    options:
      - ["any", ":ppn=12"]
      - ["vis", ":ppn=12:vis:gpus=1"]
      - ["gpu", ":ppn=12:gpus=1"]
      - ["bigmem", ":ppn=12:bigmem"]
      - ["hugemem", ":ppn=32:hugemem"]
```