### PR TITLE
add texlive module to bc_osc_rstudio_server

### DIFF
--- a/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
+++ b/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
@@ -29,6 +29,6 @@ attributes:
       <%- end -%>
   <% end %>
   node_type: "any"
-  version: "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server"
+  version: "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive"
   include_tutorials: "0"
 submit: submit.yml.erb


### PR DESCRIPTION
Same as the update made to the [regular owens rstudio_server](https://github.com/OSC/bc_osc_rstudio_server/pull/26). Users cannot save and create PDF markdown files without this module.