### PR TITLE
update rstudio stat form to include new classes and modules

### DIFF
--- a/stat.osc.edu/apps/bc_osc_rstudio_server/form.js
+++ b/stat.osc.edu/apps/bc_osc_rstudio_server/form.js
@@ -1,0 +1,114 @@
+'use strict'
+
+
+const account_lookup = {
+  "STAT2480":      "PAS1641",
+  "STAT3202":      "PAS1644",
+  "STAT5730":      "PAS1642",
+  "ANTHROP9982":   "PAS1723",
+  "TDAI":          "PAS1732",
+}
+
+var staff = false;
+
+/**
+ * Add a change listener to the version select
+ */
+function set_version_change_hander() {
+  const version_select = $("#batch_connect_session_context_version");
+
+  version_select.change(function(event){
+    change_project(event);
+  });
+}
+
+/**
+ * Change a project form value given a change from in version.
+ * 
+ * @param  {Object} event The change event
+ */
+function change_project(event){
+  if(staff) {
+    return;
+  }
+
+  for(var cls in account_lookup){
+    var found = RegExp(cls).test(event.target.value);
+
+    if(found){
+      const project = $('#batch_connect_session_context_project')
+      project.val(account_lookup[cls])
+    }
+  }
+
+}
+
+/**
+ * Toggle the visibilty of a form group
+ *
+ * @param      {string}    form_id  The form identifier
+ * @param      {boolean}   show     Whether to show or hide
+ */
+function toggle_visibilty_of_form_group(form_id, show) {
+  let form_element = $(form_id);
+  let parent = form_element;
+
+  while (
+    (! parent[0].classList.contains('form-group')) &&
+    (! parent.is('html')) // ensure that we don't loop infinitely
+  ) {
+    parent = parent.parent();
+  }
+
+  // If parent is HTML then something has gone wrong and visibility should not be changed
+  if ( parent.is('html') ) {
+    return;
+  }
+
+  if(show) {
+    parent.show();
+  } else {
+    parent.hide();
+  }
+}
+
+/**
+ * Set the staff variable given what's in the form
+ */
+function set_staff() {
+  const staff_ele = $('#batch_connect_session_context_staff');
+
+  if(staff_ele.val() == "1") {
+    staff = true;
+  }
+}
+
+/**
+ * Initialize the project element
+ */
+function init_project() {
+  if(staff) {
+    return;
+  }
+
+  const version = $("#batch_connect_session_context_version");
+  const project = $("#batch_connect_session_context_version");
+
+  for(var cls in account_lookup){
+    var found = RegExp(cls).test(version.val());
+
+    if(found){
+      const project = $('#batch_connect_session_context_project')
+      project.val(account_lookup[cls])
+    }
+  }
+
+}
+
+
+set_staff();
+
+set_version_change_hander();
+init_project();
+toggle_visibilty_of_form_group('#batch_connect_session_context_project', staff);
+toggle_visibilty_of_form_group('#batch_connect_session_context_staff', false);

--- a/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
+++ b/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
@@ -4,7 +4,7 @@
   staff = groups.include?('oscall')
 
   new_modules = "app_rstudio_server/3.6.3 project/classes"
-  old_modules = "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive"
+  old_modules = "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive project/classes"
 
   group_lookup = {
     "STAT 2480"     => "PAS1641",

--- a/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
+++ b/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
@@ -1,11 +1,28 @@
 <%-
 
-groups = OodSupport::Process.groups.map(&:name)
-classes = {
-  "STAT 2480" => "PAS1641",
-  "STAT 3202" => "PAS1644",
-  "STAT 5730" => "PAS1642",
-}.select { |k,v| groups.include?(v) }
+  groups = OodSupport::Process.groups.map(&:name)
+  staff = groups.include?('oscall')
+
+  new_modules = "app_rstudio_server/3.6.3 project/classes"
+  old_modules = "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive"
+
+  group_lookup = {
+    "STAT 2480"     => "PAS1641",
+    "STAT 3202"     => "PAS1644",
+    "STAT 5730"     => "PAS1642",
+    "ANTHRO 9982"   => "PAS1723",
+    "TDAI Workshop" => "PAS1732",
+  }.select { |k,v| groups.include?(v) }
+
+  # only include options if you're in that project
+  # or cheat for staff
+  classes = {
+    "STAT 2480"     => "#{old_modules} class/STAT2480",
+    "STAT 3202"     => "#{old_modules} class/STAT3202",
+    "STAT 5730"     => "#{old_modules} class/STAT5730",
+    "ANTHRO 9982"   => "#{new_modules} class/ANTHROP9982",
+    "TDAI Workshop" => "#{new_modules} class/TDAI",
+  }.select { |k,v| group_lookup.has_key?(k) || staff }
 
 -%>
 ---
@@ -17,18 +34,20 @@ form:
   - num_cores
   - project
   - include_tutorials
+  - staff
 attributes:
   num_cores: 1
-  <% unless classes.empty? %>
-  project:
-    widget: "select"
-    help: "For given class, an associated OSC project will be charged for this session."
-    options:
-      <%- classes.each do |class_name, account| -%>
-      - [ "<%= class_name %> (<%= account %>)", "<%= account %>" ]
-      <%- end -%>
-  <% end %>
   node_type: "any"
-  version: "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive"
+  version:
+    widget: "select"
+    label: "Class Materials"
+    options:
+    <%- classes.each do |class_name, class_modules| -%>
+      - [ "<%= class_name %>", "<%= class_modules %>" ]
+    <%- end -%>
+    required: true
   include_tutorials: "0"
+  staff:
+    widget: "check_box"
+    value: <%= staff ? "1" : "0" %>
 submit: submit.yml.erb


### PR DESCRIPTION
In draft at the moment because we're working with sci-apps to get it right before deploying.

But this updates the stats deployment with new classes/workshops available and these new classes use new modules.