### PR TITLE
stats form needs checked_value not value

### DIFF
--- a/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
+++ b/stat.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
@@ -55,5 +55,5 @@ attributes:
   include_tutorials: "0"
   staff:
     widget: "check_box"
-    value: <%= staff ? "1" : "0" %>
+    checked_value: <%= staff ? "1" : "0" %>
 submit: submit.yml.erb


### PR DESCRIPTION
OK sorry for the noise.  The hidden staff toggle isn't working right because I was setting `value` instead of `checked_value`. 