### PR TITLE
fix XDG_RUNTIME_DIR

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
@@ -17,7 +17,7 @@ batch_connect:
     [[ $(type -t module) == "function"  ]] && export -f module
 
     # MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u)
-    export XDG_RUNTIME_DIR=$TMPDIR
+    export XDG_RUNTIME_DIR="$TMPDIR/xdg_runtime"
 
 script:
   native:

--- a/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
@@ -18,5 +18,4 @@ script:
     <%- end %>
   job_environment:
     <%# MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u) %>
-    <%# also with using the relative path, XDG prepends $TMPDIR to this %>
-    XDG_RUNTIME_DIR: "xdg/<%= ENV['USER'] %>"
+    XDG_RUNTIME_DIR: "<%= Dir.mktmpdir %>"

--- a/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -17,7 +17,7 @@ batch_connect:
     [[ $(type -t module) == "function"  ]] && export -f module
 
     # MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u)
-    export XDG_RUNTIME_DIR=$TMPDIR
+    export XDG_RUNTIME_DIR="$TMPDIR/xdg_runtime"
 
 script:
   native:

--- a/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -18,5 +18,4 @@ script:
     <%- end %>
   job_environment:
     <%# MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u) %>
-    <%# also with using the relative path, XDG prepends $TMPDIR to this %>
-    XDG_RUNTIME_DIR: "xdg/<%= ENV['USER'] %>"
+    XDG_RUNTIME_DIR: "<%= Dir.mktmpdir %>"

--- a/ood.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ood.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -17,7 +17,7 @@ batch_connect:
     [[ $(type -t module) == "function"  ]] && export -f module
 
     # MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u)
-    export XDG_RUNTIME_DIR=$TMPDIR
+    export XDG_RUNTIME_DIR="$TMPDIR/xdg_runtime"
 
 script:
   native:

--- a/ood.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ood.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -18,5 +18,4 @@ script:
     <%- end %>
   job_environment:
     <%# MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u) %>
-    <%# also with using the relative path, XDG prepends $TMPDIR to this %>
-    XDG_RUNTIME_DIR: "xdg/<%= ENV['USER'] %>"
+    XDG_RUNTIME_DIR: "<%= Dir.mktmpdir %>"


### PR DESCRIPTION
apparently relative paths for XDG_RUNTIME_DIR create something in $TMPDIR, but actually use $HOME. So this was created $HOME/xdg files.