### PR TITLE
set XDG_RUNTIME_DIR using before_script

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
@@ -11,11 +11,16 @@
               end
 -%>
 ---
+batch_connect:
+  before_script: |
+    # Export the module function if it exists
+    [[ $(type -t module) == "function"  ]] && export -f module
+
+    # MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u)
+    export XDG_RUNTIME_DIR=$TMPDIR
+
 script:
   native:
     <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
     <%- end %>
-  job_environment:
-    <%# MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u) %>
-    XDG_RUNTIME_DIR: "<%= Dir.mktmpdir %>"

--- a/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -11,11 +11,16 @@
               end
 -%>
 ---
+batch_connect:
+  before_script: |
+    # Export the module function if it exists
+    [[ $(type -t module) == "function"  ]] && export -f module
+
+    # MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u)
+    export XDG_RUNTIME_DIR=$TMPDIR
+
 script:
   native:
     <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
     <%- end %>
-  job_environment:
-    <%# MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u) %>
-    XDG_RUNTIME_DIR: "<%= Dir.mktmpdir %>"

--- a/ood.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ood.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -11,11 +11,16 @@
               end
 -%>
 ---
+batch_connect:
+  before_script: |
+    # Export the module function if it exists
+    [[ $(type -t module) == "function"  ]] && export -f module
+
+    # MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u)
+    export XDG_RUNTIME_DIR=$TMPDIR
+
 script:
   native:
     <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
     <%- end %>
-  job_environment:
-    <%# MATE acts strange in pitzer-exp and doesn't like /var/run/$(id -u) %>
-    XDG_RUNTIME_DIR: "<%= Dir.mktmpdir %>"


### PR DESCRIPTION
if before_script string content is specified, this will be placed into
the job script instead of before.sh being sourced

since bc_desktop only exports the module function we just repeat that
and then set XDG_RUNTIME_DIR to $TMPDIR

XDG_RUNTIME_DIR is supposed to be 700, owned by the user, exist only for
the duration of the app run, and then be deleted; using $TMPDIR of the
batch job ensures all these occur