### PR TITLE
Fix Hello OpenMP World in C for Slurm

### DIFF
--- a/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/manifest.yml
+++ b/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/manifest.yml
@@ -1,0 +1,5 @@
+name: Hello OpenMP World in C
+host: pitzer-exp
+script: omp-hello.sh
+notes: |
+   A job template for implementing an OpenMP job on Pitzer Expansion.

--- a/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.c
+++ b/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.c
@@ -1,0 +1,36 @@
+/*
+ ============================================================================
+ Name        : omp-hello.c
+ Author      : 
+ Version     :
+ Copyright   : Your copyright notice
+ Description : Hello OpenMP World in C
+ ============================================================================
+ */
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+/**
+ * Hello OpenMP World prints the number of threads and the current thread id
+ */
+int main (int argc, char *argv[]) {
+
+  int numThreads, tid;
+
+  /* This creates a team of threads; each thread has own copy of variables  */
+#pragma omp parallel private(numThreads, tid)
+ {
+   tid = omp_get_thread_num();
+   printf("Hello World from thread number %d\n", tid);
+
+   /* The following is executed by the master thread only (tid=0) */
+   if (tid == 0)
+     {
+       numThreads = omp_get_num_threads();
+       printf("Number of threads is %d\n", numThreads);
+     }
+ }
+ return 0;
+}
+

--- a/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#SBATCH --job-name="Simple OpenMP job"
+#SBATCH -J ondemand/sys/myjobs/omp_job_slurm
+#SBATCH --output=omp-hello.out
+#SBATCH -t 00:01:00
+#SBATCH --nodes=1
+#SBATCH --exclusive
+
+# Load the OpenMPI module
+module load openmpi
+
+#
+# Move to the directory where the job was submitted
+#
+cd $SLURM_SUBMIT_DIR
+cp omp-hello.c $TMPDIR
+cd $TMPDIR
+
+#
+# Compile omp-hello.c
+#
+mpicc omp-hello.c -o omp-hello
+
+#
+# Run omp-hello
+#
+srun ./omp-hello

--- a/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -9,7 +9,7 @@
 
 # Load the OpenMPI module
 module load intel/19.0.5
-module load openmpi/4.0.3-hpcx
+module load openmpi/4.0.3
 
 #
 # Move to the directory where the job was submitted

--- a/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -26,4 +26,4 @@ mpicc -qopenmp omp-hello.c -o omp-hello
 #
 # Run omp-hello
 #
-mpiexec ./omp-hello
+mpiexec -n 24 ./omp-hello

--- a/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -26,4 +26,5 @@ mpicc -qopenmp omp-hello.c -o omp-hello
 #
 # Run omp-hello
 #
-mpiexec -n 24 ./omp-hello
+export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
+srun --export=ALL -n 1 ./omp-hello

--- a/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/apps.awesim.org/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -8,7 +8,8 @@
 #SBATCH --exclusive
 
 # Load the OpenMPI module
-module load openmpi
+module load intel/19.0.5
+module load openmpi/4.0.3-hpcx
 
 #
 # Move to the directory where the job was submitted
@@ -20,9 +21,9 @@ cd $TMPDIR
 #
 # Compile omp-hello.c
 #
-mpicc omp-hello.c -o omp-hello
+mpicc -qopenmp omp-hello.c -o omp-hello
 
 #
 # Run omp-hello
 #
-srun ./omp-hello
+mpiexec ./omp-hello

--- a/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/manifest.yml
+++ b/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/manifest.yml
@@ -1,0 +1,5 @@
+name: Hello OpenMP World in C
+host: pitzer-exp
+script: omp-hello.sh
+notes: |
+   A job template for implementing an OpenMP job on Pitzer Expansion.

--- a/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.c
+++ b/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.c
@@ -1,0 +1,36 @@
+/*
+ ============================================================================
+ Name        : omp-hello.c
+ Author      : 
+ Version     :
+ Copyright   : Your copyright notice
+ Description : Hello OpenMP World in C
+ ============================================================================
+ */
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+/**
+ * Hello OpenMP World prints the number of threads and the current thread id
+ */
+int main (int argc, char *argv[]) {
+
+  int numThreads, tid;
+
+  /* This creates a team of threads; each thread has own copy of variables  */
+#pragma omp parallel private(numThreads, tid)
+ {
+   tid = omp_get_thread_num();
+   printf("Hello World from thread number %d\n", tid);
+
+   /* The following is executed by the master thread only (tid=0) */
+   if (tid == 0)
+     {
+       numThreads = omp_get_num_threads();
+       printf("Number of threads is %d\n", numThreads);
+     }
+ }
+ return 0;
+}
+

--- a/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#SBATCH --job-name="Simple OpenMP job"
+#SBATCH -J ondemand/sys/myjobs/omp_job_slurm
+#SBATCH --output=omp-hello.out
+#SBATCH -t 00:01:00
+#SBATCH --nodes=1
+#SBATCH --exclusive
+
+# Load the OpenMPI module
+module load openmpi
+
+#
+# Move to the directory where the job was submitted
+#
+cd $SLURM_SUBMIT_DIR
+cp omp-hello.c $TMPDIR
+cd $TMPDIR
+
+#
+# Compile omp-hello.c
+#
+mpicc omp-hello.c -o omp-hello
+
+#
+# Run omp-hello
+#
+srun ./omp-hello

--- a/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -26,4 +26,4 @@ mpicc -qopenmp omp-hello.c -o omp-hello
 #
 # Run omp-hello
 #
-mpiexec ./omp-hello
+mpiexec -n 24 ./omp-hello

--- a/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -9,7 +9,7 @@
 
 # Load the OpenMPI module
 module load intel/19.0.5
-module load openmpi/4.0.3-hpcx
+module load openmpi/4.0.3
 
 #
 # Move to the directory where the job was submitted
@@ -26,4 +26,5 @@ mpicc -qopenmp omp-hello.c -o omp-hello
 #
 # Run omp-hello
 #
-mpiexec -n 24 ./omp-hello
+export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
+srun --export=ALL -n 1 ./omp-hello

--- a/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ondemand.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -8,7 +8,8 @@
 #SBATCH --exclusive
 
 # Load the OpenMPI module
-module load openmpi
+module load intel/19.0.5
+module load openmpi/4.0.3-hpcx
 
 #
 # Move to the directory where the job was submitted
@@ -20,9 +21,9 @@ cd $TMPDIR
 #
 # Compile omp-hello.c
 #
-mpicc omp-hello.c -o omp-hello
+mpicc -qopenmp omp-hello.c -o omp-hello
 
 #
 # Run omp-hello
 #
-srun ./omp-hello
+mpiexec ./omp-hello

--- a/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/manifest.yml
+++ b/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/manifest.yml
@@ -1,0 +1,5 @@
+name: Hello OpenMP World in C
+host: pitzer-exp
+script: omp-hello.sh
+notes: |
+   A job template for implementing an OpenMP job on Pitzer Expansion.

--- a/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.c
+++ b/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.c
@@ -1,0 +1,36 @@
+/*
+ ============================================================================
+ Name        : omp-hello.c
+ Author      : 
+ Version     :
+ Copyright   : Your copyright notice
+ Description : Hello OpenMP World in C
+ ============================================================================
+ */
+
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+/**
+ * Hello OpenMP World prints the number of threads and the current thread id
+ */
+int main (int argc, char *argv[]) {
+
+  int numThreads, tid;
+
+  /* This creates a team of threads; each thread has own copy of variables  */
+#pragma omp parallel private(numThreads, tid)
+ {
+   tid = omp_get_thread_num();
+   printf("Hello World from thread number %d\n", tid);
+
+   /* The following is executed by the master thread only (tid=0) */
+   if (tid == 0)
+     {
+       numThreads = omp_get_num_threads();
+       printf("Number of threads is %d\n", numThreads);
+     }
+ }
+ return 0;
+}
+

--- a/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#SBATCH --job-name="Simple OpenMP job"
+#SBATCH -J ondemand/sys/myjobs/omp_job_slurm
+#SBATCH --output=omp-hello.out
+#SBATCH -t 00:01:00
+#SBATCH --nodes=1
+#SBATCH --exclusive
+
+# Load the OpenMPI module
+module load openmpi
+
+#
+# Move to the directory where the job was submitted
+#
+cd $SLURM_SUBMIT_DIR
+cp omp-hello.c $TMPDIR
+cd $TMPDIR
+
+#
+# Compile omp-hello.c
+#
+mpicc omp-hello.c -o omp-hello
+
+#
+# Run omp-hello
+#
+srun ./omp-hello

--- a/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -26,4 +26,4 @@ mpicc -qopenmp omp-hello.c -o omp-hello
 #
 # Run omp-hello
 #
-mpiexec ./omp-hello
+mpiexec -n 24 ./omp-hello

--- a/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -27,4 +27,4 @@ mpicc -qopenmp omp-hello.c -o omp-hello
 # Run omp-hello
 #
 export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
-srun -n 1 ./omp-hello
+srun --export=ALL -n 1 ./omp-hello

--- a/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -9,7 +9,7 @@
 
 # Load the OpenMPI module
 module load intel/19.0.5
-module load openmpi/4.0.3-hpcx
+module load openmpi/4.0.3
 
 #
 # Move to the directory where the job was submitted
@@ -26,4 +26,5 @@ mpicc -qopenmp omp-hello.c -o omp-hello
 #
 # Run omp-hello
 #
-mpiexec -n 24 ./omp-hello
+export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
+srun -n 1 ./omp-hello

--- a/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
+++ b/ood-test.osc.edu/apps/myjobs/templates/Simple_OMP_Job_Slurm/omp-hello.sh
@@ -8,7 +8,8 @@
 #SBATCH --exclusive
 
 # Load the OpenMPI module
-module load openmpi
+module load intel/19.0.5
+module load openmpi/4.0.3-hpcx
 
 #
 # Move to the directory where the job was submitted
@@ -20,9 +21,9 @@ cd $TMPDIR
 #
 # Compile omp-hello.c
 #
-mpicc omp-hello.c -o omp-hello
+mpicc -qopenmp omp-hello.c -o omp-hello
 
 #
 # Run omp-hello
 #
-srun ./omp-hello
+mpiexec ./omp-hello


### PR DESCRIPTION
Job output:

```
Hello World from thread number 16
Hello World from thread number 46
Hello World from thread number 15
Hello World from thread number 12
Hello World from thread number 19
Hello World from thread number 28
Hello World from thread number 17
Hello World from thread number 1
Hello World from thread number 24
Hello World from thread number 14
Hello World from thread number 32
Hello World from thread number 0
Hello World from thread number 40
Number of threads is 48
Hello World from thread number 20
Hello World from thread number 23
Hello World from thread number 33
Hello World from thread number 29
Hello World from thread number 8
Hello World from thread number 35
Hello World from thread number 30
Hello World from thread number 34
Hello World from thread number 22
Hello World from thread number 21
Hello World from thread number 45
Hello World from thread number 9
Hello World from thread number 3
Hello World from thread number 13
Hello World from thread number 25
...
```

Closes #88.
