### PR TITLE
Fix LAMMPS for Slurm

### DIFF
--- a/apps.awesim.org/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/manifest.yml
+++ b/apps.awesim.org/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/manifest.yml
@@ -1,0 +1,6 @@
+name: Basic LAMMPS Parallel Job - Pitzer Expansion
+host: pitzer-exp
+script: slurm_script.sh
+notes: |
+  A Basic LAMMPS Parallel Job for the OSC Pitzer Expansion cluster
+  https://www.osc.edu/resources/available_software/software_list/lammps

--- a/apps.awesim.org/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
+++ b/apps.awesim.org/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
@@ -1,34 +1,28 @@
 #!/bin/bash
 #SBATCH -J ondemand/sys/myjobs/basic_lammps_parallel
 #SBATCH --time=00:30:00
-#SBATCH --nodes=2 
-#SBATCH --ntasks-per-node=40
-#SBATCH -S /bin/bash
+#SBATCH --nodes=2
 
 #  A Basic LAMMPS Parallel Job for the OSC Pitzer cluster
 # https://www.osc.edu/resources/available_software/software_list/lammps
 
 # emit verbose details on the job's queuing.
 scontrol show job $SLURM_JOBID
+
 #
 # The following lines set up the LAMMPS environment
 #
-module load lammps
-module list
-export OMP_NUM_THREADS=80 # this must match nodes * ppn
+module load intel/19.0.5 mvapich2/2.3.4 lammps/3Mar20
+
 #
 # Move to the directory where the job was submitted
 #
-sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $SLURM_SUBMIT_DIR
-cd $SLURM_SUBMIT_DIR
-sbcast -p in.crack $TMPDIR
+
 cd $TMPDIR
+sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $TMPDIR/in.crack
+
 #
 # Run LAMMPS
 #
-lammps < in.crack
-#
-# Now, copy data (or move) back once the simulation has completed
-#
-sgather -p '*' $SLURM_SUBMIT_DIR
-ls -al
+export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
+srun --export=ALL -n 2 lammps < $TMPDIR/in.crack

--- a/apps.awesim.org/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
+++ b/apps.awesim.org/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#SBATCH -J ondemand/sys/myjobs/basic_lammps_parallel
+#SBATCH --time=00:30:00
+#SBATCH --nodes=2 
+#SBATCH --ntasks-per-node=40
+#SBATCH -S /bin/bash
+
+#  A Basic LAMMPS Parallel Job for the OSC Pitzer cluster
+# https://www.osc.edu/resources/available_software/software_list/lammps
+
+# emit verbose details on the job's queuing.
+scontrol show job $SLURM_JOBID
+#
+# The following lines set up the LAMMPS environment
+#
+module load lammps
+module list
+export OMP_NUM_THREADS=80 # this must match nodes * ppn
+#
+# Move to the directory where the job was submitted
+#
+sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $SLURM_SUBMIT_DIR
+cd $SLURM_SUBMIT_DIR
+sbcast -p in.crack $TMPDIR
+cd $TMPDIR
+#
+# Run LAMMPS
+#
+lammps < in.crack
+#
+# Now, copy data (or move) back once the simulation has completed
+#
+sgather -p '*' $SLURM_SUBMIT_DIR
+ls -al

--- a/ondemand.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/manifest.yml
+++ b/ondemand.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/manifest.yml
@@ -1,0 +1,6 @@
+name: Basic LAMMPS Parallel Job - Pitzer Expansion
+host: pitzer-exp
+script: slurm_script.sh
+notes: |
+  A Basic LAMMPS Parallel Job for the OSC Pitzer Expansion cluster
+  https://www.osc.edu/resources/available_software/software_list/lammps

--- a/ondemand.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
+++ b/ondemand.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
@@ -1,34 +1,28 @@
 #!/bin/bash
 #SBATCH -J ondemand/sys/myjobs/basic_lammps_parallel
 #SBATCH --time=00:30:00
-#SBATCH --nodes=2 
-#SBATCH --ntasks-per-node=40
-#SBATCH -S /bin/bash
+#SBATCH --nodes=2
 
 #  A Basic LAMMPS Parallel Job for the OSC Pitzer cluster
 # https://www.osc.edu/resources/available_software/software_list/lammps
 
 # emit verbose details on the job's queuing.
 scontrol show job $SLURM_JOBID
+
 #
 # The following lines set up the LAMMPS environment
 #
-module load lammps
-module list
-export OMP_NUM_THREADS=80 # this must match nodes * ppn
+module load intel/19.0.5 mvapich2/2.3.4 lammps/3Mar20
+
 #
 # Move to the directory where the job was submitted
 #
-sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $SLURM_SUBMIT_DIR
-cd $SLURM_SUBMIT_DIR
-sbcast -p in.crack $TMPDIR
+
 cd $TMPDIR
+sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $TMPDIR/in.crack
+
 #
 # Run LAMMPS
 #
-lammps < in.crack
-#
-# Now, copy data (or move) back once the simulation has completed
-#
-sgather -p '*' $SLURM_SUBMIT_DIR
-ls -al
+export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
+srun --export=ALL -n 2 lammps < $TMPDIR/in.crack

--- a/ondemand.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
+++ b/ondemand.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#SBATCH -J ondemand/sys/myjobs/basic_lammps_parallel
+#SBATCH --time=00:30:00
+#SBATCH --nodes=2 
+#SBATCH --ntasks-per-node=40
+#SBATCH -S /bin/bash
+
+#  A Basic LAMMPS Parallel Job for the OSC Pitzer cluster
+# https://www.osc.edu/resources/available_software/software_list/lammps
+
+# emit verbose details on the job's queuing.
+scontrol show job $SLURM_JOBID
+#
+# The following lines set up the LAMMPS environment
+#
+module load lammps
+module list
+export OMP_NUM_THREADS=80 # this must match nodes * ppn
+#
+# Move to the directory where the job was submitted
+#
+sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $SLURM_SUBMIT_DIR
+cd $SLURM_SUBMIT_DIR
+sbcast -p in.crack $TMPDIR
+cd $TMPDIR
+#
+# Run LAMMPS
+#
+lammps < in.crack
+#
+# Now, copy data (or move) back once the simulation has completed
+#
+sgather -p '*' $SLURM_SUBMIT_DIR
+ls -al

--- a/ood-test.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/manifest.yml
+++ b/ood-test.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/manifest.yml
@@ -1,0 +1,6 @@
+name: Basic LAMMPS Parallel Job - Pitzer Expansion
+host: pitzer-exp
+script: slurm_script.sh
+notes: |
+  A Basic LAMMPS Parallel Job for the OSC Pitzer Expansion cluster
+  https://www.osc.edu/resources/available_software/software_list/lammps

--- a/ood-test.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
+++ b/ood-test.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
@@ -1,34 +1,28 @@
 #!/bin/bash
 #SBATCH -J ondemand/sys/myjobs/basic_lammps_parallel
 #SBATCH --time=00:30:00
-#SBATCH --nodes=2 
-#SBATCH --ntasks-per-node=40
-#SBATCH -S /bin/bash
+#SBATCH --nodes=2
 
 #  A Basic LAMMPS Parallel Job for the OSC Pitzer cluster
 # https://www.osc.edu/resources/available_software/software_list/lammps
 
 # emit verbose details on the job's queuing.
 scontrol show job $SLURM_JOBID
+
 #
 # The following lines set up the LAMMPS environment
 #
-module load lammps
-module list
-export OMP_NUM_THREADS=80 # this must match nodes * ppn
+module load intel/19.0.5 mvapich2/2.3.4 lammps/3Mar20
+
 #
 # Move to the directory where the job was submitted
 #
-sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $SLURM_SUBMIT_DIR
-cd $SLURM_SUBMIT_DIR
-sbcast -p in.crack $TMPDIR
+
 cd $TMPDIR
+sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $TMPDIR/in.crack
+
 #
 # Run LAMMPS
 #
-lammps < in.crack
-#
-# Now, copy data (or move) back once the simulation has completed
-#
-sgather -p '*' $SLURM_SUBMIT_DIR
-ls -al
+export OMP_NUM_THREADS=$SLURM_CPUS_ON_NODE
+srun --export=ALL -n 2 lammps < $TMPDIR/in.crack

--- a/ood-test.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
+++ b/ood-test.osc.edu/apps/myjobs/templates/Basic_LAMMPS_Parallel_Job_Pitzer-Exp/slurm_script.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#SBATCH -J ondemand/sys/myjobs/basic_lammps_parallel
+#SBATCH --time=00:30:00
+#SBATCH --nodes=2 
+#SBATCH --ntasks-per-node=40
+#SBATCH -S /bin/bash
+
+#  A Basic LAMMPS Parallel Job for the OSC Pitzer cluster
+# https://www.osc.edu/resources/available_software/software_list/lammps
+
+# emit verbose details on the job's queuing.
+scontrol show job $SLURM_JOBID
+#
+# The following lines set up the LAMMPS environment
+#
+module load lammps
+module list
+export OMP_NUM_THREADS=80 # this must match nodes * ppn
+#
+# Move to the directory where the job was submitted
+#
+sbcast -p /users/appl/srb/workshops/compchem/lammps/in.crack $SLURM_SUBMIT_DIR
+cd $SLURM_SUBMIT_DIR
+sbcast -p in.crack $TMPDIR
+cd $TMPDIR
+#
+# Run LAMMPS
+#
+lammps < in.crack
+#
+# Now, copy data (or move) back once the simulation has completed
+#
+sgather -p '*' $SLURM_SUBMIT_DIR
+ls -al


### PR DESCRIPTION
**Job Output:**
```
LAMMPS (3 Mar 2020)
  using 48 OpenMP thread(s) per MPI task
Lattice spacing in x,y,z = 1.11428 1.92998 1.11428
Created orthogonal box = (0 0 -0.278569) to (111.428 77.1994 0.278569)
  2 by 1 by 1 MPI processor grid
Created 8141 atoms
  create_atoms CPU = 0.00529075 secs

...

Step Temp E_pair E_mol TotEng Press Volume 
       0  0.065993465   -3.2595015            0   -3.1984123 -0.035939913    8605.5917 
     200  0.060035253   -3.2531886            0   -3.1976149  -0.22757684    8638.5331 
     400   0.06054278   -3.2510706            0   -3.1950271  -0.42811733    8677.8288 
     600  0.060576995    -3.246816            0   -3.1907408  -0.60017647    8717.6131 
     800  0.060802753   -3.2413477            0   -3.1850635  -0.74499308    8756.4512 
    1000  0.061812114   -3.2349942            0   -3.1777756  -0.87130079    8796.9575 
    1200   0.06317147   -3.2277552            0   -3.1692783  -0.98010628    8823.1488 
...

Loop time of 3.21707 on 96 procs for 5000 steps with 8141 atoms

Performance: 402851.551 tau/day, 1554.211 timesteps/s
3153.5% CPU use with 2 MPI tasks x 48 OpenMP threads

...
```

There is one error, I'm not sure if it has relevance:
```
[p0595.ten.osc.edu:mpi_rank_0][create_intra_sock_comm] Failed to get correct process to socket binding info.Proceeding by disabling socket aware collectives support.[p0595.ten.osc.edu:mpi_rank_0][create_intra_sock_comm] Failed to get correct process to socket binding info.Proceeding by disabling socket aware collectives support.
```