### PR TITLE
only update myjobs DB records if the database exists

### DIFF
--- a/apps.awesim.org/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
+++ b/apps.awesim.org/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do |config|
   ActiveSupport.on_load(:active_record) do
     Workflow.where(batch_host: 'pitzer-exp').update_all(batch_host: 'pitzer')
-  end
+  end if File.exist?("#{ENV['HOME']}/ondemand/data/sys/myjobs/production.sqlite3")
 end
 

--- a/apps.awesim.org/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
+++ b/apps.awesim.org/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do |config|
   ActiveSupport.on_load(:active_record) do
     Workflow.where(batch_host: 'pitzer-exp').update_all(batch_host: 'pitzer')
-  end if File.exist?("#{ENV['HOME']}/ondemand/data/sys/myjobs/production.sqlite3")
+  end if Configuration.production_database_path.file?
 end
 

--- a/ondemand.osc.edu/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
+++ b/ondemand.osc.edu/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do |config|
   ActiveSupport.on_load(:active_record) do
     Workflow.where(batch_host: 'pitzer-exp').update_all(batch_host: 'pitzer')
-  end
+  end if File.exist?("#{ENV['HOME']}/ondemand/data/sys/myjobs/production.sqlite3")
 end
 

--- a/ondemand.osc.edu/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
+++ b/ondemand.osc.edu/apps/myjobs/initializers/ood_appkit_pitzer_exp_fix.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do |config|
   ActiveSupport.on_load(:active_record) do
     Workflow.where(batch_host: 'pitzer-exp').update_all(batch_host: 'pitzer')
-  end if File.exist?("#{ENV['HOME']}/ondemand/data/sys/myjobs/production.sqlite3")
+  end if Configuration.production_database_path.file?
 end
 


### PR DESCRIPTION
Brand new users can't create myjobs databases because we hit this initializer and there's no workflow table yet.

So this adds a guard clause.