### PR TITLE
Fix Active Jobs filter for Pitzer jobs

### DIFF
--- a/apps.awesim.org/apps/activejobs/initializers/filter.rb
+++ b/apps.awesim.org/apps/activejobs/initializers/filter.rb
@@ -4,5 +4,5 @@ Filter.list.insert(1, Filter.new.tap { |f|
   f.title = "Your Group's Jobs (#{group})"
   f.filter_id = "group"
   # N.B. Need to use :egroup here for now. My Oodsupport group name is 'appl' but job 'Account_Name' is 'PZS0002'
-  f.filter_block = Proc.new { |job| job.native[:egroup] == group }
+  f.filter_block = Proc.new { |job| job.native[:egroup] == group || job.native[:group_name] == group || job.accounting_id.to_s.downcase == group.downcase }
 })

--- a/ondemand.osc.edu/apps/activejobs/initializers/filter.rb
+++ b/ondemand.osc.edu/apps/activejobs/initializers/filter.rb
@@ -4,5 +4,5 @@ Filter.list.insert(1, Filter.new.tap { |f|
   f.title = "Your Group's Jobs (#{group})"
   f.filter_id = "group"
   # N.B. Need to use :egroup here for now. My Oodsupport group name is 'appl' but job 'Account_Name' is 'PZS0002'
-  f.filter_block = Proc.new { |job| job.native[:egroup] == group }
+  f.filter_block = Proc.new { |job| job.native[:egroup] == group || job.native[:group_name] == group || job.accounting_id.to_s.downcase == group.downcase }
 })


### PR DESCRIPTION
This PR fixes the Active Jobs filter to show jobs that are submitted to the Pitzer cluster. 
![image](https://user-images.githubusercontent.com/6081892/95218869-be23d000-07c2-11eb-9429-d7df76ed0512.png)
Jobs submitted with the Linux Host Adapter aren't shown still, see bug report here: https://github.com/OSC/ondemand/issues/693