### PR TITLE
show project field if no classrooms are available.

### DIFF
--- a/class.osc.edu/apps/bc_osc_jupyter/form.js
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.js
@@ -110,10 +110,23 @@ function set_staff() {
   }
 }
 
+/**
+ * Alert users if they're launching a regular version of this
+ * app with no extra classroom materials,
+ */
+function alert_if_one_version(one_version) {
+  if(one_version) {
+    alert('You are not a part of any classroom project. The Jupyter launched here will not include classroom materials.');
+  }
+}
+
 set_staff();
 
+var one_version = $('#batch_connect_session_context_version').length == 0;
+var show_project =  one_version || staff;
+
+alert_if_one_version(one_version);
 set_version_change_handler();
-show_project = $('#batch_connect_session_context_version').length == 0 || staff;
 toggle_visibility_of_form_group('#batch_connect_session_context_project', show_project);
 toggle_visibility_of_form_group('#batch_connect_session_context_staff', false);
 

--- a/class.osc.edu/apps/bc_osc_jupyter/form.js
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.js
@@ -113,7 +113,8 @@ function set_staff() {
 set_staff();
 
 set_version_change_handler();
-toggle_visibility_of_form_group('#batch_connect_session_context_project', staff);
+show_project = $('#batch_connect_session_context_version').length == 0 || staff;
+toggle_visibility_of_form_group('#batch_connect_session_context_project', show_project);
 toggle_visibility_of_form_group('#batch_connect_session_context_staff', false);
 
 // Fake some events to initialize things

--- a/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
@@ -1,7 +1,12 @@
 <%- 
 
-  groups = OodSupport::Process.groups.map(&:name)
-  staff = groups.include?('oscall')
+  raw_groups = OodSupport::User.new.groups
+
+  groups = raw_groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+
+  staff = raw_groups.map(&:name).include?('oscall')
 
   base_modules = "project/classes"
 

--- a/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
@@ -48,6 +48,12 @@ attributes:
     min: 0
     max: 28
     step: 1
+  project:
+    widget: select
+    options:
+    <%- for group in groups -%>
+      - "<%= group %>"
+    <%- end %>
   <%- if classes.empty? -%>
   version: "app_jupyter/2.1.4"
   <%- else -%>

--- a/class.osc.edu/apps/bc_osc_jupyter/submit.yml.erb
+++ b/class.osc.edu/apps/bc_osc_jupyter/submit.yml.erb
@@ -4,9 +4,7 @@ batch_connect:
   conn_params:
     - jupyter_api
 script:
-  <%- if project.present? -%>
-  accounting_id: <%= project %>
-  <%- end -%>
+  accounting_id: "<%= project %>"
   native:
     - "--nodes"
     - "1"

--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.js
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.js
@@ -118,7 +118,8 @@ function set_staff() {
 set_staff();
 
 set_version_change_hander();
-toggle_visibility_of_form_group('#batch_connect_session_context_project', staff);
+show_project = $('#batch_connect_session_context_version').length == 0 || staff;
+toggle_visibility_of_form_group('#batch_connect_session_context_project', show_project);
 toggle_visibility_of_form_group('#batch_connect_session_context_staff', false);
 
 // Fake some events to initialize things

--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.js
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.js
@@ -115,10 +115,23 @@ function set_staff() {
   }
 }
 
+/**
+ * Alert users if they're launching a regular version of this
+ * app with no extra classroom materials,
+ */
+function alert_if_one_version(one_version) {
+  if(one_version) {
+    alert('You are not a part of any classroom project. The RStduio launched here will not include classroom materials.');
+  }
+}
+
 set_staff();
 
+var one_version = $('#batch_connect_session_context_version').length == 0;
+var show_project =  one_version || staff;
+
+alert_if_one_version(one_version);
 set_version_change_hander();
-show_project = $('#batch_connect_session_context_version').length == 0 || staff;
 toggle_visibility_of_form_group('#batch_connect_session_context_project', show_project);
 toggle_visibility_of_form_group('#batch_connect_session_context_staff', false);
 

--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
@@ -1,7 +1,12 @@
 <%-
 
-  groups = OodSupport::Process.groups.map(&:name)
-  staff = groups.include?('oscall')
+  raw_groups = OodSupport::User.new.groups
+
+  groups = raw_groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+
+  staff = raw_groups.map(&:name).include?('oscall')
 
   new_modules = "project/classes"
   old_modules = "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive project/classes"
@@ -68,6 +73,12 @@ attributes:
     max: 28
     step: 1
   node_type: "any"
+  project:
+    widget: select
+    options:
+    <%- for group in groups -%>
+      - "<%= group %>"
+    <%- end %>
   <%- if  classes.empty? -%>
   version: "gnu/7.3.0 mkl/2018.0.3 R/3.6.0 rstudio/1.1.380_server texlive"
   <%- else -%>

--- a/class.osc.edu/apps/bc_osc_rstudio_server/submit.yml.erb
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/submit.yml.erb
@@ -2,9 +2,7 @@
 batch_connect:
   template: "basic"
 script:
-  <%- if project.present? -%>
-  accounting_id: <%= project %>
-  <%- end -%>
+  accounting_id: "<%= project %>"
   native:
     - "--nodes"
     - "1"


### PR DESCRIPTION
Users with no classroom projects will now be able to view a project select menu. This will start a jupyter & rstudio app similar to the regular ondemand with no class modules loaded.