### PR TITLE
class apps should use account instead of 'project' 

### DIFF
--- a/class.osc.edu/apps/bc_osc_jupyter/form.js
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.js
@@ -19,17 +19,17 @@ function set_version_change_handler() {
   const version_select = $("#batch_connect_session_context_version");
 
   version_select.change(function(event){
-    change_project(event);
+    change_account(event);
     show_cores(event);
   });
 }
 
 /**
- * Change a project form value given a change from in version.
+ * Change the account form value given a change from in version.
  * 
  * @param  {Object} event The change event
  */
-function change_project(event){
+function change_account(event){
   if(staff) {
     return;
   }
@@ -38,15 +38,15 @@ function change_project(event){
     var found = RegExp(cls).test(event.target.value);
 
     if(found){
-      const project = $('#batch_connect_session_context_project')
-      project.val(account_lookup[cls])
+      const account = $('#batch_connect_session_context_account')
+      account.val(account_lookup[cls])
     }
   }
 }
 
 /**
- * Show the cores element if the event changes the project to
- * allowed projects.
+ * Show the cores element if the event changes the classroom to
+ * allowed classrooms.
  *
  * @param  {Object} event The change event
  */
@@ -123,13 +123,13 @@ function alert_if_one_version(one_version) {
 set_staff();
 
 var one_version = $('#batch_connect_session_context_version').length == 0;
-var show_project =  one_version || staff;
+var show_account =  one_version || staff;
 
 alert_if_one_version(one_version);
 set_version_change_handler();
-toggle_visibility_of_form_group('#batch_connect_session_context_project', show_project);
+toggle_visibility_of_form_group('#batch_connect_session_context_account', show_account);
 toggle_visibility_of_form_group('#batch_connect_session_context_staff', false);
 
 // Fake some events to initialize things
-change_project({ target: document.querySelector('#batch_connect_session_context_version') });
+change_account({ target: document.querySelector('#batch_connect_session_context_version') });
 show_cores({ target: document.querySelector('#batch_connect_session_context_version') });

--- a/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
@@ -35,7 +35,7 @@ form:
   - version
   - jupyterlab_switch
   - bc_num_hours
-  - project
+  - account
   - node_type
   - num_cores
   - staff
@@ -53,7 +53,7 @@ attributes:
     min: 0
     max: 28
     step: 1
-  project:
+  account:
     widget: select
     options:
     <%- for group in groups -%>

--- a/class.osc.edu/apps/bc_osc_jupyter/submit.yml.erb
+++ b/class.osc.edu/apps/bc_osc_jupyter/submit.yml.erb
@@ -4,7 +4,7 @@ batch_connect:
   conn_params:
     - jupyter_api
 script:
-  accounting_id: "<%= project %>"
+  accounting_id: "<%= account %>"
   native:
     - "--nodes"
     - "1"

--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.js
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.js
@@ -30,17 +30,17 @@ function set_version_change_hander() {
   const version_select = $("#batch_connect_session_context_version");
 
   version_select.change(function(event){
-    change_project(event);
+    change_account(event);
     show_cores(event);
   });
 }
 
 /**
- * Change a project form value given a change from in version.
+ * Change the account form value given a change from in version.
  * 
  * @param  {Object} event The change event
  */
-function change_project(event){
+function change_account(event){
   if(staff) {
     return;
   }
@@ -49,8 +49,8 @@ function change_project(event){
     var found = RegExp(cls).test(event.target.value);
 
     if(found){
-      const project = $('#batch_connect_session_context_project');
-      project.val(account_lookup[cls]);
+      const account = $('#batch_connect_session_context_account');
+      account.val(account_lookup[cls]);
     }
   }
 }
@@ -128,13 +128,13 @@ function alert_if_one_version(one_version) {
 set_staff();
 
 var one_version = $('#batch_connect_session_context_version').length == 0;
-var show_project =  one_version || staff;
+var show_account =  one_version || staff;
 
 alert_if_one_version(one_version);
 set_version_change_hander();
-toggle_visibility_of_form_group('#batch_connect_session_context_project', show_project);
+toggle_visibility_of_form_group('#batch_connect_session_context_account', show_account);
 toggle_visibility_of_form_group('#batch_connect_session_context_staff', false);
 
 // Fake some events to initialize things
-change_project({ target: document.querySelector('#batch_connect_session_context_version') });
+show_account({ target: document.querySelector('#batch_connect_session_context_version') });
 show_cores({ target: document.querySelector('#batch_connect_session_context_version') });

--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.yml.erb
@@ -61,7 +61,7 @@ form:
   - bc_num_hours
   - node_type
   - num_cores
-  - project
+  - account
   - include_tutorials
   - staff
 attributes:
@@ -73,7 +73,7 @@ attributes:
     max: 28
     step: 1
   node_type: "any"
-  project:
+  account:
     widget: select
     options:
     <%- for group in groups -%>

--- a/class.osc.edu/apps/bc_osc_rstudio_server/submit.yml.erb
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/submit.yml.erb
@@ -2,7 +2,7 @@
 batch_connect:
   template: "basic"
 script:
-  accounting_id: "<%= project %>"
+  accounting_id: "<%= account %>"
   native:
     - "--nodes"
     - "1"


### PR DESCRIPTION
class apps should use account instead of 'project' to align with their actual versions. Otherwise I get errors about `undefined local variable or method 'account'`.