### PR TITLE
Fix classes

### DIFF
--- a/class.osc.edu/apps/bc_osc_jupyter/form.js
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.js
@@ -38,8 +38,8 @@ function change_account(event){
     var found = RegExp(cls).test(event.target.value);
 
     if(found){
-      const account = $('#batch_connect_session_context_account')
-      account.val(account_lookup[cls])
+      const account = $('#batch_connect_session_context_account');
+      account.val(account_lookup[cls]).change();
     }
   }
 }

--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.js
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.js
@@ -50,7 +50,7 @@ function change_account(event){
 
     if(found){
       const account = $('#batch_connect_session_context_account');
-      account.val(account_lookup[cls]);
+      account.val(account_lookup[cls]).change();
     }
   }
 }

--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.js
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.js
@@ -136,5 +136,5 @@ toggle_visibility_of_form_group('#batch_connect_session_context_account', show_a
 toggle_visibility_of_form_group('#batch_connect_session_context_staff', false);
 
 // Fake some events to initialize things
-show_account({ target: document.querySelector('#batch_connect_session_context_version') });
+change_account({ target: document.querySelector('#batch_connect_session_context_version') });
 show_cores({ target: document.querySelector('#batch_connect_session_context_version') });


### PR DESCRIPTION
First there's a small bug introduced in #150 where I should have called `change_account` instead of `show_account`.

Secondly, I think the initialization doesn't quite work with using `.val()` on a select widget (it kept using my cached value, not the classroom project it should have), so this forces the change by calling `change()` on it.