### PR TITLE
vis and gpu desktops should respect the core counts

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
@@ -28,13 +28,13 @@
                 base_slurm_args + p20_node
 
               when "gpu-any"
-                base_slurm_args + ["--gpus-per-node", "#{gpus}"]
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpus}"]
               when "gpu-40core"
                 base_slurm_args + p18_node + ["--gpus-per-node", "#{gpus}"]
               when "gpu-48core"
                 base_slurm_args + p20_node + ["--gpus-per-node", "#{gpus}"]
               when "vis"
-                base_slurm_args + ["--gpus-per-node", "#{gpus}", "--gres", "vis"]
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpus}", "--gres", "vis"]
               when "densegpu"
                 base_slurm_args + p20_node + ["--gpus-per-node", "4"]
 

--- a/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -28,13 +28,13 @@
                 base_slurm_args + p20_node
 
               when "gpu-any"
-                base_slurm_args + ["--gpus-per-node", "#{gpus}"]
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpus}"]
               when "gpu-40core"
                 base_slurm_args + p18_node + ["--gpus-per-node", "#{gpus}"]
               when "gpu-48core"
                 base_slurm_args + p20_node + ["--gpus-per-node", "#{gpus}"]
               when "vis"
-                base_slurm_args + ["--gpus-per-node", "#{gpus}", "--gres", "vis"]
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpus}", "--gres", "vis"]
               when "densegpu"
                 base_slurm_args + p20_node + ["--gpus-per-node", "4"]
 


### PR DESCRIPTION
Vis and GPU desktops currently cannot request any more than 1 core (the default). This fixes that.