### PR TITLE
upgrade dependencies to current bundler 2 and ruby 2.7+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,22 +13,24 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+
+      - name: Setup Ruby using Bundler
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.5'
-      - uses: actions/cache@v2
-        with:
-          path: ~/vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
-      - name: setup bundler & shellcheck
+          ruby-version: "2.7.1"
+          bundler-cache: true
+          bundler: "2.1.4"
+
+      - name: Install shellcheck
         run: |
-          gem install bundler -v 1.17.3
-          bundle config path ~/vendor/bundle
           sudo apt-get update
           sudo apt-get install shellcheck
-      - name: install gems
+
+      - name: Install gems
         run: bundle install
-      - name: test
+
+      - name: Test
         run: bundle exec rake test
-      - name: shellcheck
+
+      - name: Shellcheck
         run: shellcheck hooks/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.14.2)
-    rake (13.0.1)
+    minitest (5.14.3)
+    rake (13.0.3)
 
 PLATFORMS
   ruby
@@ -12,4 +12,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
upgrade dependencies to current bundler 2 and ruby 2.7+ because we need to be able to locally run rake test which we can't at the moment.