### PR TITLE
check gpfs fs for outage before adding paths

### DIFF
--- a/apps.awesim.org/apps/dashboard/initializers/ood.rb
+++ b/apps.awesim.org/apps/dashboard/initializers/ood.rb
@@ -1,18 +1,23 @@
 # AweSim OOD config
 
-OodFilesApp.candidate_favorite_paths.tap do |paths|
-  # add project space directories
-  projects = User.new.groups.map(&:name).grep(/^P./)
-  paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
+def add_paths
+  OodFilesApp.candidate_favorite_paths.tap do |paths|
+    # add project space directories
+    projects = User.new.groups.map(&:name).grep(/^P./)
+    paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
 
-  # add scratch space directories
-  paths << Pathname.new("/fs/scratch/#{User.new.name}")
-  paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
+    # add scratch space directories
+    paths << Pathname.new("/fs/scratch/#{User.new.name}")
+    paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
 
-  # add ess scratch and project directories
-  paths.concat projects.map { |p| Pathname.new("/fs/ess/scratch/#{p}")  }
-  paths.concat projects.map { |p| Pathname.new("/fs/ess/#{p}")  }
+    # add ess scratch and project directories
+    paths.concat projects.map { |p| Pathname.new("/fs/ess/scratch/#{p}")  }
+    paths.concat projects.map { |p| Pathname.new("/fs/ess/#{p}")  }
+  end
 end
+
+fs_outage = `grep node_file_test_failure /var/lib/node_exporter/textfile_collector/autofs-file-test.prom | grep -q ' 1'; echo $?`
+add_paths unless fs_outage.chomp == "0"
 
 # don't show develop dropdown unless you are setup for app sharing
 Configuration.app_development_enabled = UsrRouter.base_path.directory?

--- a/class.osc.edu/apps/dashboard/initializers/stats2480.rb
+++ b/class.osc.edu/apps/dashboard/initializers/stats2480.rb
@@ -1,13 +1,18 @@
-OodFilesApp.candidate_favorite_paths.tap do |paths|
-  # add project space directories
-  projects = User.new.groups.map(&:name).grep(/^P./)
-  paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
+def add_paths
+  OodFilesApp.candidate_favorite_paths.tap do |paths|
+    # add project space directories
+    projects = User.new.groups.map(&:name).grep(/^P./)
+    paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
 
-  # add scratch space directories
-  paths << Pathname.new("/fs/scratch/#{User.new.name}")
-  paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
+    # add scratch space directories
+    paths << Pathname.new("/fs/scratch/#{User.new.name}")
+    paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
 
-  # add ess scratch and project directories
-  paths.concat projects.map { |p| Pathname.new("/fs/ess/scratch/#{p}")  }
-  paths.concat projects.map { |p| Pathname.new("/fs/ess/#{p}")  }
+    # add ess scratch and project directories
+    paths.concat projects.map { |p| Pathname.new("/fs/ess/scratch/#{p}")  }
+    paths.concat projects.map { |p| Pathname.new("/fs/ess/#{p}")  }
+  end
 end
+
+fs_outage = `grep node_file_test_failure /var/lib/node_exporter/textfile_collector/autofs-file-test.prom | grep -q ' 1'; echo $?`
+add_paths unless fs_outage.chomp == "0"

--- a/ondemand.osc.edu/apps/dashboard/initializers/ood.rb
+++ b/ondemand.osc.edu/apps/dashboard/initializers/ood.rb
@@ -1,16 +1,22 @@
-OodFilesApp.candidate_favorite_paths.tap do |paths|
-  # add project space directories
-  projects = User.new.groups.map(&:name).grep(/^P./)
-  paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
 
-  # add scratch space directories
-  paths << Pathname.new("/fs/scratch/#{User.new.name}")
-  paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
+def add_paths
+  OodFilesApp.candidate_favorite_paths.tap do |paths|
+    # add project space directories
+    projects = User.new.groups.map(&:name).grep(/^P./)
+    paths.concat projects.map { |p| Pathname.new("/fs/project/#{p}")  }
 
-  # add ess scratch and project directories
-  paths.concat projects.map { |p| Pathname.new("/fs/ess/scratch/#{p}")  }
-  paths.concat projects.map { |p| Pathname.new("/fs/ess/#{p}")  }
+    # add scratch space directories
+    paths << Pathname.new("/fs/scratch/#{User.new.name}")
+    paths.concat projects.map { |p| Pathname.new("/fs/scratch/#{p}")  }
+
+    # add ess scratch and project directories
+    paths.concat projects.map { |p| Pathname.new("/fs/ess/scratch/#{p}")  }
+    paths.concat projects.map { |p| Pathname.new("/fs/ess/#{p}")  }
+  end
 end
+
+fs_outage = `grep node_file_test_failure /var/lib/node_exporter/textfile_collector/autofs-file-test.prom | grep -q ' 1'; echo $?`
+add_paths unless fs_outage.chomp == "0"
 
 NavConfig.categories_whitelist=true
 


### PR DESCRIPTION
check gpfs fs for outage before adding paths. this way OnDemand will still work while there's a GPFS outage.