### PR TITLE
Disable use_extension for jupyter classroom

### DIFF
--- a/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
+++ b/class.osc.edu/apps/bc_osc_jupyter/form.yml.erb
@@ -48,6 +48,7 @@ cluster: "owens"
 form:
   - version
   - jupyterlab_switch
+  - use_extension
   - bc_num_hours
   - account
   - node_type
@@ -57,6 +58,7 @@ form:
 attributes:
   node_type: "any"
   classroom: 1
+  use_extension: 0
   jupyterlab_switch:
     widget: "check_box"
     label: "Use JupyterLab instead of Jupyter Notebook?"


### PR DESCRIPTION
Set `0` to the attribute `use_extension` so jupyter classroom will not break when we enable jupyterlab extension feature in   bc_osc_jupyter 