### PR TITLE
add a force option for gpfs outages

### DIFF
--- a/apps.awesim.org/apps/dashboard/initializers/ood.rb
+++ b/apps.awesim.org/apps/dashboard/initializers/ood.rb
@@ -17,7 +17,7 @@ def add_paths
 end
 
 fs_outage = `grep node_file_test_failure /var/lib/node_exporter/textfile_collector/autofs-file-test.prom | grep -q ' 1'; echo $?`
-add_paths unless fs_outage.chomp == "0"
+add_paths if fs_outage.chomp == "1" && !File.exist?('/etc/ood/config/gpfs_outage')
 
 # don't show develop dropdown unless you are setup for app sharing
 Configuration.app_development_enabled = UsrRouter.base_path.directory?

--- a/class.osc.edu/apps/dashboard/initializers/stats2480.rb
+++ b/class.osc.edu/apps/dashboard/initializers/stats2480.rb
@@ -15,4 +15,4 @@ def add_paths
 end
 
 fs_outage = `grep node_file_test_failure /var/lib/node_exporter/textfile_collector/autofs-file-test.prom | grep -q ' 1'; echo $?`
-add_paths unless fs_outage.chomp == "0"
+add_paths if fs_outage.chomp == "1" && !File.exist?('/etc/ood/config/gpfs_outage')

--- a/ondemand.osc.edu/apps/dashboard/initializers/ood.rb
+++ b/ondemand.osc.edu/apps/dashboard/initializers/ood.rb
@@ -16,7 +16,7 @@ def add_paths
 end
 
 fs_outage = `grep node_file_test_failure /var/lib/node_exporter/textfile_collector/autofs-file-test.prom | grep -q ' 1'; echo $?`
-add_paths unless fs_outage.chomp == "0"
+add_paths if fs_outage.chomp == "1" && !File.exist?('/etc/ood/config/gpfs_outage')
 
 NavConfig.categories_whitelist=true
 


### PR DESCRIPTION
add a force option for gpfs outages. This is so that we can drop a file here and we won't add those paths even if the Prometheus alert hasn't fired yet.