### PR TITLE
init cores to 1 bc most classes can't change it

### DIFF
--- a/class.osc.edu/apps/bc_osc_rstudio_server/form.js
+++ b/class.osc.edu/apps/bc_osc_rstudio_server/form.js
@@ -149,7 +149,7 @@ function set_cluster(event) {
   var node_type = 'any';
   var cluster = 'owens';
   var num_hours_max = undefined;
-  var cores = $('#batch_connect_session_context_num_cores').val();
+  var cores = 1;
 
   k8s_classrooms.forEach(cls => {
     var k8s = RegExp(cls['name']).test(event.target.value);


### PR DESCRIPTION
init cores to 1 bc most classes can't change it. If you were in the class with 4 and another class - switching back and forth you'd end up starting the second class with 4 cores when you should only have used 1.