### PR TITLE
ondemand to use the logo in navbar

### DIFF
--- a/ondemand.osc.edu/apps/dashboard/env
+++ b/ondemand.osc.edu/apps/dashboard/env
@@ -2,6 +2,7 @@ MOTD_PATH="/etc/motd"
 MOTD_FORMAT="osc"
 
 OOD_DASHBOARD_LOGO="/public/logo.png"
+OOD_DASHBOARD_HEADER_IMG_LOGO="/public/logo.png"
 OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/client_support_request"
 OOD_DASHBOARD_SUPPORT_EMAIL="oschelp@osc.edu"
 


### PR DESCRIPTION
ondemand to use the logo in navbar. Login to class.osc.edu (or dev/test) to see the affect as it's already got this configuration.