### PR TITLE
Fix Keycloak URL to work with Keycloak 18

### DIFF
--- a/ondemand.osc.edu/apps/dashboard/initializers/ood.rb
+++ b/ondemand.osc.edu/apps/dashboard/initializers/ood.rb
@@ -30,4 +30,4 @@ when /test/
 else
   idp = 'https://idp.osc.edu'
 end
-ENV['OOD_DASHBOARD_HELP_CUSTOM_URL'] = "#{idp}/auth/realms/osc/account/identity"
+ENV['OOD_DASHBOARD_HELP_CUSTOM_URL'] = "#{idp}/realms/osc/account/identity"


### PR DESCRIPTION
@johrstrom This will have to be rolled out to test sometime next week and then likely save for production until June downtime.  If that large gap between test and production will cause issues, we can just delay test rollout till week before downtime.