### PR TITLE
Revert "ondemand to use the logo in navbar"

### DIFF
--- a/ondemand.osc.edu/apps/dashboard/env
+++ b/ondemand.osc.edu/apps/dashboard/env
@@ -2,7 +2,6 @@ MOTD_PATH="/etc/motd"
 MOTD_FORMAT="osc"
 
 OOD_DASHBOARD_LOGO="/public/logo.png"
-OOD_DASHBOARD_HEADER_IMG_LOGO="/public/logo.png"
 OOD_DASHBOARD_SUPPORT_URL="https://www.osc.edu/contact/client_support_request"
 OOD_DASHBOARD_SUPPORT_EMAIL="oschelp@osc.edu"
 


### PR DESCRIPTION
Reverts OSC/osc-ood-config#218.  Images are not accessible in 2.0.