### PR TITLE
specify gpus on owens & pitzer

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/owens.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/owens.yml.erb
@@ -21,6 +21,7 @@ form:
   - account
   - bc_num_hours
   - cores
+  - gpus
   - bc_num_slots
   - licenses
   - node_type
@@ -55,6 +56,7 @@ attributes:
     min: 1
     max: 28
     step: 1
+  gpus: ""
   licenses:
     help: |
       Licenses are comma separeated in the format '\<name\>@osc:\<# of licenses\>' like

--- a/apps.awesim.org/apps/bc_desktop/pitzer.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/pitzer.yml.erb
@@ -20,6 +20,7 @@ form:
   - desktop
   - account
   - bc_num_hours
+  - gpus
   - cores
   - bc_num_slots
   - licenses
@@ -55,6 +56,7 @@ attributes:
     min: 1
     max: 48
     step: 1
+  gpus: ""
   licenses:
     help: |
       Licenses are comma separeated in the format '\<name\>@osc:\<# of licenses\>' like

--- a/ondemand.osc.edu/apps/bc_desktop/owens.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/owens.yml.erb
@@ -21,6 +21,7 @@ form:
   - account
   - bc_num_hours
   - cores
+  - gpus
   - bc_num_slots
   - licenses
   - node_type
@@ -55,6 +56,7 @@ attributes:
     min: 1
     max: 28
     step: 1
+  gpus: ""
   licenses:
     help: |
       Licenses are comma separeated in the format '\<name\>@osc:\<# of licenses\>' like

--- a/ondemand.osc.edu/apps/bc_desktop/pitzer.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/pitzer.yml.erb
@@ -20,6 +20,7 @@ form:
   - desktop
   - account
   - bc_num_hours
+  - gpus
   - cores
   - bc_num_slots
   - licenses
@@ -55,6 +56,7 @@ attributes:
     min: 1
     max: 48
     step: 1
+  gpus: ""
   licenses:
     help: |
       Licenses are comma separeated in the format '\<name\>@osc:\<# of licenses\>' like


### PR DESCRIPTION
the gpu stuff for ascend broke the other desktops. so this adds an empty gpu field for them.