### PR TITLE
enable module directories on all portals

### DIFF
--- a/apps.awesim.org/apps/dashboard/env
+++ b/apps.awesim.org/apps/dashboard/env
@@ -28,3 +28,5 @@ OOD_QUOTA_PATH=/users/reporting/storage/quota/netapp.netapp-home.ten.osc.edu-use
 OOD_BC_DYNAMIC_JS=1
 
 OOD_FACL_DOMAIN='osc.edu'
+
+OOD_MODULE_FILE_DIR="/users/reporting/lmod"

--- a/apps.totalsim.us/apps/dashboard/env
+++ b/apps.totalsim.us/apps/dashboard/env
@@ -19,3 +19,5 @@ OOD_DASHBOARD_PASSWD_URL="https://my.osc.edu"
 OOD_APP_SHARING=1
 
 OOD_FACL_DOMAIN='osc.edu'
+
+OOD_MODULE_FILE_DIR="/users/reporting/lmod"

--- a/ondemand.osc.edu/apps/dashboard/env
+++ b/ondemand.osc.edu/apps/dashboard/env
@@ -34,3 +34,5 @@ OOD_APP_SHARING=1
 OOD_BC_DYNAMIC_JS=1
 
 OOD_FACL_DOMAIN='osc.edu'
+
+OOD_MODULE_FILE_DIR="/users/reporting/lmod"


### PR DESCRIPTION
enable module directories on all portals. This will enable us to use the automatic modules (`auto_modules_<module>`) as described in the documentation below.

https://osc.github.io/ood-documentation/latest/how-tos/app-development/interactive/form.html#auto-bc-form-options
