### PR TITLE
enable gnome desktops

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/ascend.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/ascend.yml.erb
@@ -35,6 +35,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome"]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Ascend cluster].

--- a/apps.awesim.org/apps/bc_desktop/owens.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/owens.yml.erb
@@ -35,6 +35,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome"]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Owens cluster].

--- a/apps.awesim.org/apps/bc_desktop/pitzer.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/pitzer.yml.erb
@@ -35,6 +35,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome"]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Pitzer cluster].

--- a/apps.awesim.org/apps/bc_desktop/vdi.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/vdi.yml.erb
@@ -42,6 +42,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome", data-option-for-cluster-ascend-login: false ]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Owens] or [Pitzer] clusters.

--- a/ondemand.osc.edu/apps/bc_desktop/ascend.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/ascend.yml.erb
@@ -35,6 +35,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome"]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Ascend cluster].

--- a/ondemand.osc.edu/apps/bc_desktop/owens.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/owens.yml.erb
@@ -35,6 +35,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome"]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Owens cluster].

--- a/ondemand.osc.edu/apps/bc_desktop/pitzer.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/pitzer.yml.erb
@@ -35,6 +35,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome"]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Pitzer cluster].

--- a/ondemand.osc.edu/apps/bc_desktop/vdi.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/vdi.yml.erb
@@ -42,6 +42,7 @@ attributes:
     options:
       - ["Xfce", "xfce"]
       - ["Mate", "mate"]
+      - ["Gnome", "gnome", data-option-for-cluster-ascend-login: false ]
     help: |
       This will launch either the [Xfce] or [Mate] desktop environment on the
       [Owens] or [Pitzer] clusters.


### PR DESCRIPTION
enable gnome desktops now that Gnome is fixed for 3.1.