### PR TITLE
Gpu bug fix

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
@@ -19,33 +19,44 @@
     return tasks_per_node + [ "--constraint", "48core" ]
   end
 
-  def plus_gpus(arr, gpu_arr)
-    gpu_count.to_i > 0 ? arr + gpu_arr : arr
+  # gpu_count will always return at least 1, so take care when calling it.
+  def gpu_count
+    if !gpus.nil? && !gpus.empty? && gpus.to_i.positive?
+      gpus
+    else
+      1
+    end
   end
 
-  def gpu_count
-    gpus.to_s.to_i
+  # any* node types can possible get a gpu if they've set gpu >= 1
+  def possible_gpus
+    if gpus.to_s.to_i.positive?
+      ["--gpus-per-node", "#{gpu_count}"]
+    else
+      []
+    end
   end
 
   slurm_args = case node_type
               # 'any' case handled by scheduler, this is just a quick short circuit
               when "any"
-                plus_gpus(base_slurm_args + any_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + any_node + possible_gpus
+
               when "any-40core"
-                base_slurm_args + p18_node
+                base_slurm_args + p18_node + possible_gpus
               when "any-48core"
-                base_slurm_args + p20_node
+                base_slurm_args + p20_node + possible_gpus
 
               when "gpu-any"
-                plus_gpus(base_slurm_args + any_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpu_count}"]
               when "gpu-40core"
-                plus_gpus(base_slurm_args + p18_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + p18_node + ["--gpus-per-node", "#{gpu_count}"]
               when "gpu-48core"
-                plus_gpus(base_slurm_args + p20_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + p20_node + ["--gpus-per-node", "#{gpu_count}"]
               when "vis"
-                plus_gpus(base_slurm_args + any_node, ["--gpus-per-node", "#{gpu_count}", "--gres", "vis"])
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpu_count}", "--gres", "vis"]
               when "densegpu"
-                plus_gpus(base_slurm_args + p20_node, ["--gpus-per-node", "4"])
+                base_slurm_args + p20_node + ["--gpus-per-node", "4"]
 
               # using partitions here is easier than specifying memory requests
               when "largemem"
@@ -54,6 +65,7 @@
               when "hugemem"
                 partition = bc_num_slots.to_i > 1 ? "hugemem-parallel" : "hugemem"
                 base_slurm_args + tasks_per_node + ["--partition", partition ]
+
               else
                 base_slurm_args
               end

--- a/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/slurm.yml.erb
@@ -24,11 +24,7 @@
   end
 
   def gpu_count
-    if !gpus.nil? && !gpus.empty? && gpus.to_i >= 0
-      gpus
-    else
-      1
-    end
+    gpus.to_s.to_i
   end
 
   slurm_args = case node_type

--- a/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -19,33 +19,44 @@
     return tasks_per_node + [ "--constraint", "48core" ]
   end
 
-  def plus_gpus(arr, gpu_arr)
-    gpu_count.to_i > 0 ? arr + gpu_arr : arr
+  # gpu_count will always return at least 1, so take care when calling it.
+  def gpu_count
+    if !gpus.nil? && !gpus.empty? && gpus.to_i.positive?
+      gpus
+    else
+      1
+    end
   end
 
-  def gpu_count
-    gpus.to_s.to_i
+  # any* node types can possible get a gpu if they've set gpu >= 1
+  def possible_gpus
+    if gpus.to_s.to_i.positive?
+      ["--gpus-per-node", "#{gpu_count}"]
+    else
+      []
+    end
   end
 
   slurm_args = case node_type
               # 'any' case handled by scheduler, this is just a quick short circuit
               when "any"
-                plus_gpus(base_slurm_args + any_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + any_node + possible_gpus
+
               when "any-40core"
-                base_slurm_args + p18_node
+                base_slurm_args + p18_node + possible_gpus
               when "any-48core"
-                base_slurm_args + p20_node
+                base_slurm_args + p20_node + possible_gpus
 
               when "gpu-any"
-                plus_gpus(base_slurm_args + any_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpu_count}"]
               when "gpu-40core"
-                plus_gpus(base_slurm_args + p18_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + p18_node + ["--gpus-per-node", "#{gpu_count}"]
               when "gpu-48core"
-                plus_gpus(base_slurm_args + p20_node, ["--gpus-per-node", "#{gpu_count}"])
+                base_slurm_args + p20_node + ["--gpus-per-node", "#{gpu_count}"]
               when "vis"
-                plus_gpus(base_slurm_args + any_node, ["--gpus-per-node", "#{gpu_count}", "--gres", "vis"])
+                base_slurm_args + any_node + ["--gpus-per-node", "#{gpu_count}", "--gres", "vis"]
               when "densegpu"
-                plus_gpus(base_slurm_args + p20_node, ["--gpus-per-node", "4"])
+                base_slurm_args + p20_node + ["--gpus-per-node", "4"]
 
               # using partitions here is easier than specifying memory requests
               when "largemem"
@@ -54,6 +65,7 @@
               when "hugemem"
                 partition = bc_num_slots.to_i > 1 ? "hugemem-parallel" : "hugemem"
                 base_slurm_args + tasks_per_node + ["--partition", partition ]
+
               else
                 base_slurm_args
               end

--- a/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/slurm.yml.erb
@@ -24,11 +24,7 @@
   end
 
   def gpu_count
-    if !gpus.nil? && !gpus.empty? && gpus.to_i >= 0
-      gpus
-    else
-      1
-    end
+    gpus.to_s.to_i
   end
 
   slurm_args = case node_type


### PR DESCRIPTION
There's a bug right now where we're always requesting GPUs after #254. This kinda reverts that back to what it was before then adds the ability to request `any` node type with `gpus` set to 1 or more and get a gpu node.