### PR TITLE
force XDG_RUNTIME_DIR to be a new tmp directory

### DIFF
--- a/apps.awesim.org/apps/bc_desktop/submit/vdi.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/vdi.yml.erb
@@ -14,15 +14,12 @@ batch_connect:
     [[ $(type -t module) == "function"  ]] && export -f module
 
     # MATE doesn't like /var/run/$(id -u) and ascend-login doesn't have $TMPDIR
-    export XDG_RUNTIME_DIR="<%= ['ascend-login', 'cardinal-login'].include?(cluster) ? '/tmp' : '$TMPDIR' %>/xdg_runtime"
+    export XDG_RUNTIME_DIR=$(mktemp -d)
+    export APPTAINER_ENVXDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
 
     # reset SLURM_EXPORT_ENV so that things like srun & sbatch work out of the box
     export SLURM_EXPORT_ENV=ALL
 script:
-  job_environment:
-    XDG_RUNTIME_DIR: "/tmp/xdg_runtime"
-    SINGULARITY_ENVXDG_RUNTIME_DIR: "/tmp/xdg_runtime"
-    APPTAINER_ENVXDG_RUNTIME_DIR: "/tmp/xdg_runtime"
   native:
     <%- if ['ascend-login', 'cardinal-login'].include?(cluster) -%>
     singularity_container: "<%= container_lookup[cluster] %>"

--- a/apps.awesim.org/apps/bc_desktop/submit/vdi.yml.erb
+++ b/apps.awesim.org/apps/bc_desktop/submit/vdi.yml.erb
@@ -15,7 +15,7 @@ batch_connect:
 
     # MATE doesn't like /var/run/$(id -u) and ascend-login doesn't have $TMPDIR
     export XDG_RUNTIME_DIR=$(mktemp -d)
-    export APPTAINER_ENVXDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
+    export APPTAINERENV_XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
 
     # reset SLURM_EXPORT_ENV so that things like srun & sbatch work out of the box
     export SLURM_EXPORT_ENV=ALL

--- a/ondemand.osc.edu/apps/bc_desktop/submit/vdi.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/vdi.yml.erb
@@ -14,15 +14,12 @@ batch_connect:
     [[ $(type -t module) == "function"  ]] && export -f module
 
     # MATE doesn't like /var/run/$(id -u) and ascend-login doesn't have $TMPDIR
-    export XDG_RUNTIME_DIR="<%= ['ascend-login', 'cardinal-login'].include?(cluster) ? '/tmp' : '$TMPDIR' %>/xdg_runtime"
+    export XDG_RUNTIME_DIR=$(mktemp -d)
+    export APPTAINER_ENVXDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
 
     # reset SLURM_EXPORT_ENV so that things like srun & sbatch work out of the box
     export SLURM_EXPORT_ENV=ALL
 script:
-  job_environment:
-    XDG_RUNTIME_DIR: "/tmp/xdg_runtime"
-    SINGULARITY_ENVXDG_RUNTIME_DIR: "/tmp/xdg_runtime"
-    APPTAINER_ENVXDG_RUNTIME_DIR: "/tmp/xdg_runtime"
   native:
     <%- if ['ascend-login', 'cardinal-login'].include?(cluster) -%>
     singularity_container: "<%= container_lookup[cluster] %>"

--- a/ondemand.osc.edu/apps/bc_desktop/submit/vdi.yml.erb
+++ b/ondemand.osc.edu/apps/bc_desktop/submit/vdi.yml.erb
@@ -15,7 +15,7 @@ batch_connect:
 
     # MATE doesn't like /var/run/$(id -u) and ascend-login doesn't have $TMPDIR
     export XDG_RUNTIME_DIR=$(mktemp -d)
-    export APPTAINER_ENVXDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
+    export APPTAINERENV_XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR
 
     # reset SLURM_EXPORT_ENV so that things like srun & sbatch work out of the box
     export SLURM_EXPORT_ENV=ALL


### PR DESCRIPTION
force XDG_RUNTIME_DIR to be a new tmp directory because /tmp/xdg_runtime is hard coded and isn't a temporary file system local to the container.